### PR TITLE
feat: add asset hash appending

### DIFF
--- a/internal/testdata/assets/test.txt
+++ b/internal/testdata/assets/test.txt
@@ -1,0 +1,3 @@
+Fast and simple code,
+Gophers build with quiet strength,
+Concurrency flows.

--- a/internal/testdata/efs_mock.go
+++ b/internal/testdata/efs_mock.go
@@ -1,0 +1,6 @@
+package testdata
+
+import "embed"
+
+//go:embed "assets"
+var TestFiles embed.FS

--- a/ui/html/base.tmpl
+++ b/ui/html/base.tmpl
@@ -33,8 +33,8 @@
         <meta name="twitter:image:height" content="630">
         <!-- Why no twitter:image:alt? Read this: https://yoast.com/developer-blog/why-we-dont-set-the-og-image-alt-tag/ -->
 
-        <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-        <link rel="stylesheet" href="/static/css/main.css">
+        <link rel="icon" href="{{(hashAssetPath "/static/favicon.svg")}}" type="image/svg+xml">
+        <link rel="stylesheet" href="{{(hashAssetPath "/static/css/main.css")}}">
     </head>
     <body>
     {{template "header" .}}
@@ -45,7 +45,7 @@
         {{template "main" .}}
     </main>
     {{template "footer" .}}
-    <script src="/static/js/main.js" async defer></script>
+    <script src="{{(hashAssetPath "/static/js/main.js")}}" async defer></script>
     </body>
     </html>
 {{end}}


### PR DESCRIPTION
Can now call the `hashAssetPath` template function to append asset hash to asset's filename. For example, `/static/css/main.css` becomes `/static/css/main.css?v=<hash>`.