### PR TITLE
Remove the `httprouter` dependency.

### DIFF
--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -4,28 +4,24 @@ import (
 	"expvar"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
-
 	"github.com/rynhndrcksn/go-starter-site/ui"
 )
 
 // routes handles assigning all the routes for the site and what HTTP methods are used for them.
 func (app *application) routes() http.Handler {
-	// Initialize new httprouter instance.
-	router := httprouter.New()
+	// Initialize a new http.ServeMux instance.
+	mux := http.NewServeMux()
 
 	// Use the http.FileServerFS() function to create an HTTP handler which serves the embedded files in ui.Files.
 	// It's important to note that the static files are contained in the "static" folder of the ui.Files embedded filesystem.
 	// So, for example, our CSS stylesheet is located at "static/css/main.css".
-	router.Handler(http.MethodGet, "/static/*path", http.FileServerFS(ui.Files))
-
-	// Tell httprouter to use our custom notFoundResponse handler.
-	router.NotFound = http.HandlerFunc(app.notFoundHandler)
+	mux.Handle("GET /static/", http.FileServerFS(ui.Files))
 
 	// Register routes.
-	router.HandlerFunc(http.MethodGet, "/", app.homeHandler)
-	router.HandlerFunc(http.MethodGet, "/about", app.aboutHandler)
-	router.Handler(http.MethodGet, "/debug/vars", expvar.Handler())
+	mux.HandleFunc("GET /", app.notFoundHandler)
+	mux.HandleFunc("GET /{$}", app.homeHandler)
+	mux.HandleFunc("GET /about", app.aboutHandler)
+	mux.Handle("GET /debug/vars", expvar.Handler())
 
-	return app.recoverPanic(app.logRequest(app.commonHeaders(router)))
+	return app.recoverPanic(app.logRequest(app.commonHeaders(mux)))
 }

--- a/cmd/web/testutils_test.go
+++ b/cmd/web/testutils_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/alexedwards/scs/v2/memstore"
-	"github.com/julienschmidt/httprouter"
 )
 
 // newTestApplication creates a new application struct containing mocked dependencies.
@@ -93,13 +92,13 @@ func (ts *testServer) get(t *testing.T, urlPath string) (int, http.Header, strin
 }
 
 func (app *application) routeThatPanics() http.Handler {
-	// Initialize new httprouter instance.
-	router := httprouter.New()
+	// Initialize a new http.ServeMux instance.
+	mux := http.NewServeMux()
 
-	// Register route to test against:
-	router.HandlerFunc(http.MethodGet, "/server-error", func(writer http.ResponseWriter, r *http.Request) {
+	// Register a route to test against.
+	mux.HandleFunc("GET /server-error", func(writer http.ResponseWriter, r *http.Request) {
 		panic("this triggers a 500 status page")
 	})
 
-	return app.recoverPanic(router)
+	return app.recoverPanic(mux)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/alexedwards/scs/pgxstore v0.0.0-20250417082927-ab20b3feb5e9
 	github.com/alexedwards/scs/v2 v2.8.0
 	github.com/jackc/pgx/v5 v5.7.5
-	github.com/julienschmidt/httprouter v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/jackc/pgx/v5 v5.7.5/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ While on desktop, click the "Use this template" button located near the top righ
 Change the module name from `github.com/rynhndrcksn/go-starter-site` to match your repository.
 
 > [!NOTE]
-> Don't forget to update all the import paths throughout the project as well!
+> Remember to update all the import paths throughout the project as well!
 
 ## Dependencies
 
@@ -25,7 +25,6 @@ In an effort to keep third party dependencies to a minimum, only the following o
 1. https://github.com/alexedwards/scs | Session management
 2. https://github.com/alexedwards/scs/pgxstore | Store sessions in Postgres
 3. https://github.com/jackc/pgx | PostgreSQL driver
-4. https://github.com/julienschmidt/httprouter | Http router
 
 There are some development related dependencies that I recommend installing to your local machine:
 


### PR DESCRIPTION
During testing the site is still plenty performant. HttpRouter averaged ~58,000 requests per second. Go's stdlib Mux averages ~55,000 requests per second.

This performance difference is negligible. I'd rather have 1 less dependency than a 5% performance gain #YachtProblem.

Testing was done using [Bombardier](https://github.com/codesenberg/bombardier). So nothing fancy, just basic-ish HTTP load testing.